### PR TITLE
Run BCR tests in CI

### DIFF
--- a/.github/workflows/bcr_tests.yml
+++ b/.github/workflows/bcr_tests.yml
@@ -1,0 +1,27 @@
+name: Run BCR tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  bcr_tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Run BCR tests (${{ matrix.os }})
+    env:
+      BAZELISK_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        env:
+          USE_BAZEL_VERSION: last_green
+        working-directory: ./tests/bcr
+        run: bazelisk test //...

--- a/tests/bcr/.bazelrc
+++ b/tests/bcr/.bazelrc
@@ -1,2 +1,1 @@
-build --experimental_enable_bzlmod
-build --incompatible_unambiguous_label_stringification
+build --enable_bzlmod


### PR DESCRIPTION
Executes the tests in the test module also used by the Bazel Central Registry (BCR) on PRs and pushes to main.