### PR TITLE
Prepare for next release to the BCR

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,10 +1,10 @@
 module(
     name = "apple_rules_lint",
-    version = "0.2.0",
+    version = "0.3.2",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.2.1")
-bazel_dep(name = "stardoc", repo_name = "io_bazel_stardoc", version = "0.5.1")
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "stardoc", repo_name = "io_bazel_stardoc", version = "0.5.3")
 
 linter = use_extension("//lint:extensions.bzl", "linter")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "05fb57bb4ad68a360470420a3b6f5317e4f722839abc5b17ec4ef8ed465aaa47",
+    sha256 = "3fd8fec4ddec3c670bd810904e2e33170bedfe12f90adf943508184be458c8bb",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,1 @@
+workspace(name = "apple_rules_lint")


### PR DESCRIPTION
We use the next version number because that's what we'll tag that version as.